### PR TITLE
MARP-2597 Add E2E workflow and test environment support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
-    secrets:
-      mvnArgs: -Dtelsearch.apiKey=${{secrets.API_KEY}}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,6 +6,10 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v6

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v6
-    secrets:
-      mvnArgs: -Dtelsearch.apiKey=${{secrets.API_KEY}}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,17 @@
+name: E2E-Build
+
+on:
+  push:
+  schedule:
+    - cron:  '21 21 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  build:
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
+    secrets:
+      mvnArgs: -Dtelsearch.apiKey=${{secrets.API_KEY}} -DtestEnvironment=E2E

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,8 @@
 name: E2E-Build
 
 on:
-  push:
   schedule:
-    - cron:  '21 21 * * *'
+    - cron:  '0 1 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/tel-search-ch-connector-test/pom.xml
+++ b/tel-search-ch-connector-test/pom.xml
@@ -76,6 +76,7 @@
         <configuration>
           <systemPropertyVariables>
             <apiKey>${telsearch.apiKey}</apiKey>
+            <testEnvironment>${testEnvironment}</testEnvironment>
           </systemPropertyVariables>
           <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
             <disable>false</disable>

--- a/tel-search-ch-connector-test/src_test/constant/TelSearchTestConstant.java
+++ b/tel-search-ch-connector-test/src_test/constant/TelSearchTestConstant.java
@@ -4,4 +4,6 @@ public class TelSearchTestConstant {
   public static final String MOCK_SERVER_CONTEXT_DISPLAY_NAME = "Mock Server Test";
   public static final String REAL_CALL_CONTEXT_DISPLAY_NAME = "Real Server Test";
   public static final String API_KEY = "apiKey";
+  public static final String END_TO_END_TESTING_ENVIRONMENT_KEY = "testEnvironment";
+  public static final String END_TO_END_TESTING_ENVIRONMENT_VALUE = "E2E";
 }

--- a/tel-search-ch-connector-test/src_test/context/MultiEnvironmentContextProvider.java
+++ b/tel-search-ch-connector-test/src_test/context/MultiEnvironmentContextProvider.java
@@ -20,9 +20,9 @@ public class MultiEnvironmentContextProvider implements TestTemplateInvocationCo
     String testEnv = System.getProperty(TelSearchTestConstant.END_TO_END_TESTING_ENVIRONMENT_KEY);
     return switch (testEnv) {
     case TelSearchTestConstant.END_TO_END_TESTING_ENVIRONMENT_VALUE ->
-      Stream.of(new TestEnironmentInvocationContext(TelSearchTestConstant.REAL_CALL_CONTEXT_DISPLAY_NAME));
+      Stream.of(new TestEnvironmentInvocationContext(TelSearchTestConstant.REAL_CALL_CONTEXT_DISPLAY_NAME));
     default ->
-      Stream.of(new TestEnironmentInvocationContext(TelSearchTestConstant.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
+      Stream.of(new TestEnvironmentInvocationContext(TelSearchTestConstant.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
     };
   }
 }

--- a/tel-search-ch-connector-test/src_test/context/MultiEnvironmentContextProvider.java
+++ b/tel-search-ch-connector-test/src_test/context/MultiEnvironmentContextProvider.java
@@ -17,7 +17,12 @@ public class MultiEnvironmentContextProvider implements TestTemplateInvocationCo
 
   @Override
   public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
-    return Stream.of(new TestEnironmentInvocationContext(TelSearchTestConstant.REAL_CALL_CONTEXT_DISPLAY_NAME),
-        new TestEnironmentInvocationContext(TelSearchTestConstant.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
+    String testEnv = System.getProperty(TelSearchTestConstant.END_TO_END_TESTING_ENVIRONMENT_KEY);
+    return switch (testEnv) {
+    case TelSearchTestConstant.END_TO_END_TESTING_ENVIRONMENT_VALUE ->
+      Stream.of(new TestEnironmentInvocationContext(TelSearchTestConstant.REAL_CALL_CONTEXT_DISPLAY_NAME));
+    default ->
+      Stream.of(new TestEnironmentInvocationContext(TelSearchTestConstant.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
+    };
   }
 }

--- a/tel-search-ch-connector-test/src_test/context/TestEnvironmentInvocationContext.java
+++ b/tel-search-ch-connector-test/src_test/context/TestEnvironmentInvocationContext.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 
-public class TestEnironmentInvocationContext implements TestTemplateInvocationContext {
+public class TestEnvironmentInvocationContext implements TestTemplateInvocationContext {
   private String contextDisplayName;
 
-  public TestEnironmentInvocationContext(String contextDisplayName) {
+  public TestEnvironmentInvocationContext(String contextDisplayName) {
     this.contextDisplayName = contextDisplayName;
   }
 


### PR DESCRIPTION
Introduces a new GitHub Actions workflow for end-to-end (E2E) testing and updates the test configuration to support a 'testEnvironment' property. The test context provider now selects the appropriate test environment based on this property, enabling E2E-specific test execution. Also removes redundant secrets from CI and dev workflows.